### PR TITLE
Add filter on query terms

### DIFF
--- a/includes/admin/api/class-bc-admin-media-api.php
+++ b/includes/admin/api/class-bc-admin-media-api.php
@@ -557,7 +557,7 @@ class BC_Admin_Media_API {
 
 			}
 
-			$query_string = implode( "+", $query_terms );
+			$query_string = implode( "+", apply_filters( 'bc_video_query_terms', $query_terms ) );
 
 			/**
 			 * For playlists, we specify the order in the query string as follows:


### PR DESCRIPTION
If we're adding filters, we could add a filter for query terms.

One problem with the sort field, is that sorting on `published_at` returns anything with an empty published date first. This means unpublished content! If we can filter the search query terms too, we can limit the results to published videos only. 